### PR TITLE
CantactDev and LogPlayer small fixes (Extended frame, log replay and non-blocking read)

### DIFF
--- a/canard/hw/cantact.py
+++ b/canard/hw/cantact.py
@@ -1,4 +1,5 @@
 import serial
+import time
 
 from .. import can
 
@@ -12,6 +13,7 @@ class CantactDev:
 
     def start(self):
         self._dev_write('O\r')
+        self.start_time = time.time()
 
     def stop(self):
         self._dev_write('C\r')
@@ -84,6 +86,7 @@ class CantactDev:
             data.append(int(rx_str[data_offset+i*2:(data_offset+2)+i*2], 16))
             frame.data = data
 
+        frame.timestamp = time.time() - self.start_time
         return frame
 
     def send(self, frame):

--- a/canard/hw/cantact.py
+++ b/canard/hw/cantact.py
@@ -42,7 +42,12 @@ class CantactDev:
         # receive characters until a newline (\r) is hit
         rx_str = ""
         while rx_str == "" or rx_str[-1] != '\r':
-            rx_str = rx_str + self.ser.read().decode('ascii')
+            rx =  self.ser.read().decode('ascii')
+            if rx == "":
+                # Read timeout from pySerial
+                return None
+            else:
+                rx_str = rx_str + rx
 
         # check frame type
         if rx_str[0] == 'T':

--- a/canard/hw/logplayer.py
+++ b/canard/hw/logplayer.py
@@ -11,6 +11,9 @@ class LogPlayer:
         self.start_timestamp = time.time()
         self.running = True
 
+    def stop(self):
+        self.running = False
+
     def recv(self):
         assert self.running, 'not running'
         last_timestamp = 0

--- a/canard/hw/logplayer.py
+++ b/canard/hw/logplayer.py
@@ -4,14 +4,18 @@ from .. import can
 class LogPlayer:
     running = False
     def __init__(self, log_filename):
-        self.logfile = open(log_filename, 'r')
+        self.log_filename = log_filename
+        self.logfile = None
 
     def start(self):
         assert not self.running, 'cannot start, already running'
+        self.logfile = open(self.log_filename, 'r')
         self.start_timestamp = time.time()
         self.running = True
 
     def stop(self):
+        if self.logfile:
+            self.logfile.close()
         self.running = False
 
     def recv(self):

--- a/canard/hw/logplayer.py
+++ b/canard/hw/logplayer.py
@@ -31,7 +31,8 @@ class LogPlayer:
         fields = line.split(' ')
 
         id = int(fields[1], 0)
-        frame = can.Frame(id)
+        ext_id = id > 0x7FF and id <= 0x1FFFFFFF
+        frame = can.Frame(id, is_extended_id=ext_id)
 
         frame.timestamp = float(fields[0])
 


### PR DESCRIPTION
LogPlayer:
- Handle extended_id:  Mandatory for Frame.__init__()
- add a stop() method:  So it can be handled like other devices

CantactDev:
- Add a frame.timestamp:  Needed for Logger usage
- Allow non-blocking read on pySerial:  pySerial allow this and it can be useful in some contexts.